### PR TITLE
feat: change redirect on test case clone

### DIFF
--- a/tcms/testcases/views.py
+++ b/tcms/testcases/views.py
@@ -232,7 +232,7 @@ class CloneTestCaseView(View):
             if len(clone_form.cleaned_data["case"]) == 1:
                 return HttpResponseRedirect(
                     reverse(
-                        "testcases-get",
+                        "testcases-edit",
                         args=[
                             tc_dest.pk,
                         ],


### PR DESCRIPTION
Following this change, after cloning a test case the redirect is not for the 'view' page of a test case, but for the 'edit' page. This makes more sense since no one will keep a cloned test case as it is - they clone it in order to use it as a base amend it.